### PR TITLE
Allow forwarded messages in links dump channel

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -41,3 +41,5 @@ REPORTS_CHANNEL_ID=YOUR_CHANNEL_ID
 # Links Dump Channel Configuration (optional)
 # Channel ID where only links are allowed - text messages will be auto-deleted
 LINKS_DUMP_CHANNEL_ID=YOUR_LINKS_DUMP_CHANNEL_ID
+# Set to true to allow forwarded messages from other channels
+ALLOW_FORWARDED_IN_LINKS_DUMP=false

--- a/LINKS_DUMP_USAGE.md
+++ b/LINKS_DUMP_USAGE.md
@@ -10,6 +10,8 @@ Add the channel ID to your `.env` file:
 
 ```env
 LINKS_DUMP_CHANNEL_ID=your_channel_id_here
+# Optional: allow forwarding messages from other channels
+ALLOW_FORWARDED_IN_LINKS_DUMP=true
 ```
 
 To find your channel ID:
@@ -23,6 +25,7 @@ To find your channel ID:
 - Messages containing URLs (http:// or https://) are allowed to remain
 - Bot messages are ignored
 - Commands are processed normally
+- If `ALLOW_FORWARDED_IN_LINKS_DUMP` is enabled, forwarded messages from other channels are allowed
 
 ### Deleted Messages
 - Text-only messages (no URLs) are automatically deleted after 1 minute
@@ -33,6 +36,7 @@ To find your channel ID:
 
 ✅ **Allowed**: "Check out this cool article: https://example.com"
 ✅ **Allowed**: "https://github.com/user/repo - great project!"
+✅ **Allowed** (with forwarding enabled): forward of a message from #general
 ❌ **Deleted**: "What do you think about this?"
 ❌ **Deleted**: "Thanks for sharing!"
 

--- a/bot.py
+++ b/bot.py
@@ -156,10 +156,21 @@ async def handle_links_dump_channel(message: discord.Message) -> bool:
         url_pattern = r'https?://(?:[-\w.]|(?:%[\da-fA-F]{2}))+(?:/[^\s]*)?(?:\?[^\s]*)?'
         urls = re.findall(url_pattern, message.content)
         
+
         # If message contains URLs, allow it
         if urls:
             logger.info(f"Message {message.id} in links dump channel contains URL, allowing")
             return False
+
+        # Allow forwarded messages from other channels if configured
+        if getattr(config, 'allow_forwarded_in_links_dump', False):
+            if message.reference and message.reference.message_id and (
+                message.reference.channel_id != message.channel.id
+            ):
+                logger.info(
+                    f"Message {message.id} is forwarded from another channel, allowing"
+                )
+                return False
             
         # Message doesn't contain URLs, send warning and schedule deletion
         logger.info(f"Deleting non-link message {message.id} in links dump channel")

--- a/config.py
+++ b/config.py
@@ -58,6 +58,11 @@ reports_channel_id = os.getenv('REPORTS_CHANNEL_ID')
 # Channel where only links are allowed - text messages will be auto-deleted
 links_dump_channel_id = os.getenv('LINKS_DUMP_CHANNEL_ID')
 
+# Allow forwarded messages in the links dump channel (optional)
+# Environment variable: ALLOW_FORWARDED_IN_LINKS_DUMP
+# Set to "true" to keep cross-channel forwarded messages
+allow_forwarded_in_links_dump = os.getenv('ALLOW_FORWARDED_IN_LINKS_DUMP', 'false').lower() in ('1', 'true', 'yes')
+
 # Summary Command Limits
 # Maximum hours that can be requested in summary commands (7 days)
 MAX_SUMMARY_HOURS = 168

--- a/test_links_dump.py
+++ b/test_links_dump.py
@@ -50,9 +50,10 @@ async def test_handle_links_dump_channel():
     # Mock config
     mock_config = MagicMock()
     mock_config.links_dump_channel_id = "123456789"
+    mock_config.allow_forwarded_in_links_dump = True
     
     # Mock message objects
-    def create_mock_message(content, channel_id, is_bot=False):
+    def create_mock_message(content, channel_id, is_bot=False, reference=None):
         message = MagicMock()
         message.content = content
         message.channel.id = int(channel_id)
@@ -61,21 +62,28 @@ async def test_handle_links_dump_channel():
         message.author.mention = "@testuser"
         message.channel.send = AsyncMock()
         message.delete = AsyncMock()
+        message.reference = reference
         return message
     
     # Test cases
+    cross_ref = MagicMock()
+    cross_ref.message_id = 222
+    cross_ref.channel_id = 987654321
+    cross_ref.cached_message = None
+
     test_cases = [
-        # (content, channel_id, is_bot, should_be_handled, description)
-        ("Check this link: https://example.com", "123456789", False, False, "URL in links dump channel"),
-        ("Just text", "123456789", False, True, "Text only in links dump channel"),
-        ("Just text", "987654321", False, False, "Text in different channel"),
-        ("Any content", "123456789", True, False, "Bot message in links dump channel"),
+        # (content, channel_id, is_bot, reference, should_be_handled, description)
+        ("Check this link: https://example.com", "123456789", False, None, False, "URL in links dump channel"),
+        ("Just text", "123456789", False, None, True, "Text only in links dump channel"),
+        ("Just text", "987654321", False, None, False, "Text in different channel"),
+        ("Any content", "123456789", True, None, False, "Bot message in links dump channel"),
+        ("Forwarded", "123456789", False, cross_ref, False, "Forwarded message allowed"),
     ]
     
     with patch('bot.config', mock_config):
         with patch('bot.asyncio.create_task') as mock_create_task:
-            for content, channel_id, is_bot, should_be_handled, description in test_cases:
-                message = create_mock_message(content, channel_id, is_bot)
+            for content, channel_id, is_bot, reference, should_be_handled, description in test_cases:
+                message = create_mock_message(content, channel_id, is_bot, reference)
                 
                 try:
                     result = await handle_links_dump_channel(message)
@@ -100,12 +108,15 @@ def test_config_integration():
         os.environ['OPENROUTER_API_KEY'] = 'dummy_key'
         os.environ['FIRECRAWL_API_KEY'] = 'dummy_key'
         os.environ['LINKS_DUMP_CHANNEL_ID'] = '123456789'
+        os.environ['ALLOW_FORWARDED_IN_LINKS_DUMP'] = 'true'
         
         import config
         
         # Check if the new config option is available
-        if hasattr(config, 'links_dump_channel_id'):
-            print(f"✓ Config loaded, links_dump_channel_id = {config.links_dump_channel_id}")
+        if hasattr(config, 'links_dump_channel_id') and hasattr(config, 'allow_forwarded_in_links_dump'):
+            print(
+                f"✓ Config loaded, links_dump_channel_id = {config.links_dump_channel_id}, allow_forwarded = {config.allow_forwarded_in_links_dump}"
+            )
             return True
         else:
             print("✗ Config missing links_dump_channel_id attribute")


### PR DESCRIPTION
## Summary
- add `ALLOW_FORWARDED_IN_LINKS_DUMP` config option
- keep cross‑channel forwarded messages in links dump channel
- document new option in `.env.sample` and LINKS_DUMP_USAGE
- test forwarded message behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'discord')*

------
https://chatgpt.com/codex/tasks/task_e_685d5d70001c83249822f9ef4756090c